### PR TITLE
strip user without password

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,6 +96,10 @@ func Scrub(argument string) string {
 	u, err := url.ParseRequestURI(argument)
 	if err == nil && u.Host != "" && contains(allowedSchemes, u.Scheme) {
 		u.Scheme = "https"
+		// clear the user if there is no password, since it's common to use git@github.com
+		if _, isSet := u.User.Password(); !isSet {
+			u.User = nil
+		}
 		return u.String()
 	}
 	if scpUrl.MatchString(argument) {
@@ -109,7 +113,11 @@ func Scrub(argument string) string {
 			// host changed, possible attack
 			return argument
 		}
-		return newUrl
+		// clear the user if there is no password, since it's common to use git@github.com
+		if _, isSet := u.User.Password(); !isSet {
+			u.User = nil
+		}
+		return u.String()
 	}
 	return argument
 }

--- a/main.go
+++ b/main.go
@@ -96,7 +96,8 @@ func Scrub(argument string) string {
 	u, err := url.ParseRequestURI(argument)
 	if err == nil && u.Host != "" && contains(allowedSchemes, u.Scheme) {
 		u.Scheme = "https"
-		// clear the user if there is no password, since it's common to use git@github.com
+		// Clear the user if there is no password, since the URL is usually ssh://git@github.com.
+		// The username is required to tell the server you're doing Git operations, but not needed for HTTPS.
 		if _, isSet := u.User.Password(); !isSet {
 			u.User = nil
 		}
@@ -113,7 +114,8 @@ func Scrub(argument string) string {
 			// host changed, possible attack
 			return argument
 		}
-		// clear the user if there is no password, since it's common to use git@github.com
+		// Clear the user if there is no password, since the URL is usually git@github.com.
+		// The username is required to tell the server you're doing Git operations, but not needed for HTTPS.
 		if _, isSet := u.User.Password(); !isSet {
 			u.User = nil
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -49,11 +49,15 @@ func TestScrub(t *testing.T) {
 		},
 		{
 			input:    "git@github.com:dependabot/git-https-shim",
-			expected: "https://git@github.com/dependabot/git-https-shim",
+			expected: "https://github.com/dependabot/git-https-shim",
+		},
+		{
+			input:    "ssh://user:pass@github.com/dependabot/git-https-shim",
+			expected: "https://user:pass@github.com/dependabot/git-https-shim",
 		},
 		{
 			input:    "ssh://git@github.com/dependabot/git-https-shim",
-			expected: "https://git@github.com/dependabot/git-https-shim",
+			expected: "https://github.com/dependabot/git-https-shim",
 		},
 		{
 			input:    "ssh://github.com/dependabot/git-https-shim",


### PR DESCRIPTION
When specifying a Git dependency in certain ecosystems, using an SSH URL to GitHub like `ssh://git@github.com` will result in the Git-Shim creating `https://git@github.com` which is mostly harmless and technically correct, but since there's no password it's creating confusion in our downstream Proxy which won't inject credentials if it thinks there's already credentials on the request.

So this changes it to remove the user from the URL if there is no password. 